### PR TITLE
[bonus feature] implements undo/redo redux logic

### DIFF
--- a/components/UndoNotification.js
+++ b/components/UndoNotification.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from "react";
+import {
+  TouchableOpacity,
+  Text,
+  StyleSheet,
+  Dimensions,
+  Animated
+} from "react-native";
+import PropTypes from "prop-types";
+
+import Card from "./Card";
+
+const dimensions = {
+  width: Dimensions.get("window").width,
+  height: Dimensions.get("window").height
+};
+
+const AUTO_DISMISS = 6000;
+const UndoNotification = ({ undo, visible, dismiss }) => {
+  const [springValue] = useState(new Animated.Value(0.3));
+
+  const spring = () => {
+    springValue.setValue(0.3);
+    Animated.spring(springValue, {
+      toValue: 1,
+      friction: 8
+    }).start();
+  };
+
+  useEffect(() => {
+    if (visible) {
+      spring();
+      setTimeout(() => {
+        dismiss();
+      }, AUTO_DISMISS);
+    }
+  }, [visible]);
+
+  return (
+    visible && (
+      <Animated.View
+        style={{
+          ...styles.container,
+          transform: [{ scale: springValue }]
+        }}
+      >
+        <TouchableOpacity onPress={undo}>
+          <Card additionalStyles={styles.notificationContainer}>
+            <Text style={styles.undoText}>Undo?</Text>
+          </Card>
+        </TouchableOpacity>
+      </Animated.View>
+    )
+  );
+};
+
+UndoNotification.propTypes = {
+  undo: PropTypes.func.isRequired,
+  dismiss: PropTypes.func.isRequired,
+  visible: PropTypes.bool.isRequired
+};
+
+const styles = StyleSheet.create({
+  container: {
+    width: dimensions.width,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    position: "absolute",
+    bottom: 0,
+    opacity: 0.4
+  },
+  notificationContainer: {
+    width: dimensions.width - 48,
+    height: 75,
+    marginBottom: -24,
+    backgroundColor: "#3d3d3d",
+    flexDirection: "row",
+    justifyContent: "center",
+    borderRadius: 8
+  },
+  undoText: {
+    color: "white"
+  }
+});
+
+export default UndoNotification;

--- a/confgureStore.js
+++ b/confgureStore.js
@@ -2,8 +2,7 @@ import { createStore, applyMiddleware } from "redux";
 import { createLogger } from "redux-logger";
 import thunk from "redux-thunk";
 import { composeWithDevTools } from "redux-devtools-extension";
-import { persistStore, persistReducer } from "redux-persist";
-import { AsyncStorage } from "react-native";
+import { persistStore } from "redux-persist";
 
 import rootReducer from "./reducers/rootReducer";
 
@@ -11,18 +10,11 @@ export const INITIAL_STATE = {
   tasks: {}
 };
 
-const persistConfig = {
-  key: "root",
-  storage: AsyncStorage
-};
-
-const persistedReducer = persistReducer(persistConfig, rootReducer);
-
 const loggerMiddleware = createLogger();
 
 export default function configureStore(initialState = INITIAL_STATE) {
   const store = createStore(
-    persistedReducer,
+    rootReducer,
     initialState,
     process.env.NODE_ENV === "production"
       ? applyMiddleware(thunk)

--- a/confgureStore.js
+++ b/confgureStore.js
@@ -21,6 +21,5 @@ export default function configureStore(initialState = INITIAL_STATE) {
       : composeWithDevTools(applyMiddleware(thunk, loggerMiddleware))
   );
   const persistor = persistStore(store);
-
   return { store, persistor };
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",
     "redux-persist": "^6.0.0",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "redux-undo": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/reducers/rootReducer.js
+++ b/reducers/rootReducer.js
@@ -1,7 +1,29 @@
 import { combineReducers } from "redux";
+import { persistReducer } from "redux-persist";
+import undoable, { includeAction } from "redux-undo";
+import { AsyncStorage } from "react-native";
 
 import tasks from "./taskReducer";
+import { ADD_TASK, MOVE_TASK, REMOVE_TASK } from "../actions/taskActions";
 
-export default combineReducers({
-  tasks
+const tasksPersistConfig = {
+  key: "tasks",
+  storage: AsyncStorage
+};
+
+const persistConfig = {
+  key: "root",
+  storage: AsyncStorage
+};
+
+const rootReducer = combineReducers({
+  tasks: persistReducer(
+    tasksPersistConfig,
+    undoable(tasks, {
+      limit: 5,
+      filter: includeAction([ADD_TASK, MOVE_TASK, REMOVE_TASK])
+    })
+  )
 });
+
+export default persistReducer(persistConfig, rootReducer);

--- a/reducers/taskReducer.js
+++ b/reducers/taskReducer.js
@@ -27,44 +27,40 @@ export default (state = {}, action) => {
     }
     case REMOVE_TASK: {
       const { selectedDate, id } = action;
-      const newTasks = { ...state };
-      const prevIndex = newTasks[selectedDate].findIndex(
-        item => item.id === id
-      );
-      newTasks[selectedDate].splice(prevIndex, 1);
-      return {
-        ...state,
-        ...newTasks
-      };
+      const newTasks = [...state[selectedDate]];
+      const newState = { ...state };
+      const prevIndex = newTasks.findIndex(item => item.id === id);
+      newTasks.splice(prevIndex, 1);
+      newState[action.selectedDate] = newTasks;
+      return newState;
     }
     case TOGGLE_COMPLETE_TASK: {
-      const newTasks = { ...state };
-      newTasks[action.selectedDate].find(
-        t => t.id === action.task.id
-      ).completed = action.task.completed;
-      return {
-        ...state,
-        ...newTasks
-      };
+      const newTasks = [...state[action.selectedDate]];
+      const newState = { ...state };
+      const updatedTasks = newTasks.map(task => {
+        if (task.id === action.task.id) {
+          return {
+            ...task,
+            completed: action.task.completed
+          };
+        }
+        return task;
+      });
+      newState[action.selectedDate] = updatedTasks;
+      return newState;
     }
     case MOVE_TASK: {
-      const newTasks = { ...state };
       const { selectedDate, previousDate, task } = action;
+      const newState = { ...state };
+      const newTasks = [...(state[selectedDate] || [])];
+      const oldTasks = [...state[previousDate]];
+      newTasks.unshift(task);
 
-      if (newTasks[selectedDate]) {
-        newTasks[selectedDate].unshift(task);
-      } else {
-        newTasks[selectedDate] = [task];
-      }
-
-      const prevIndex = newTasks[previousDate].findIndex(
-        item => item.id === task.id
-      );
-      newTasks[previousDate].splice(prevIndex, 1);
-      return {
-        ...state,
-        ...newTasks
-      };
+      const prevIndex = oldTasks.findIndex(item => item.id === task.id);
+      oldTasks.splice(prevIndex, 1);
+      newState[selectedDate] = newTasks;
+      newState[previousDate] = oldTasks;
+      return newState;
     }
 
     default:

--- a/screens/main/index.js
+++ b/screens/main/index.js
@@ -9,34 +9,52 @@ import {
   moveTask
 } from "../../actions/taskActions";
 import Main from "./Main";
+import UndoNotification from "../../components/UndoNotification";
 
 export default () => {
+  const [showUndo, setShowUndo] = React.useState(false);
+
   const tasks = useSelector(state => state.tasks.present);
 
   const dispatch = useDispatch();
 
-  const handleAddTask = ({ task, selectedDate }) =>
+  const handleAddTask = ({ task, selectedDate }) => {
+    setShowUndo(true);
     dispatch(addTask({ task, selectedDate }));
+  };
 
   const handleToggleCompleteTask = ({ task, selectedDate }) =>
     dispatch(toggleCompleteTask({ task, selectedDate }));
 
-  const handleRemoveTask = ({ id, selectedDate }) =>
+  const handleRemoveTask = ({ id, selectedDate }) => {
+    setShowUndo(true);
     dispatch(removeTask({ id, selectedDate }));
+  };
 
-  const handleMoveTask = ({ task, selectedDate, previousDate }) =>
+  const handleMoveTask = ({ task, selectedDate, previousDate }) => {
+    setShowUndo(true);
     dispatch(moveTask({ task, selectedDate, previousDate }));
+  };
 
-  const undo = () => dispatch(ActionCreators.undo());
+  const undo = () => {
+    setShowUndo(false);
+    dispatch(ActionCreators.undo());
+  };
 
   return (
-    <Main
-      tasks={tasks}
-      handleAddTask={handleAddTask}
-      handleToggleCompleteTask={handleToggleCompleteTask}
-      handleRemoveTask={handleRemoveTask}
-      handleMoveTask={handleMoveTask}
-      undo={undo}
-    />
+    <>
+      <Main
+        tasks={tasks}
+        handleAddTask={handleAddTask}
+        handleToggleCompleteTask={handleToggleCompleteTask}
+        handleRemoveTask={handleRemoveTask}
+        handleMoveTask={handleMoveTask}
+      />
+      <UndoNotification
+        undo={undo}
+        visible={showUndo}
+        dismiss={() => setShowUndo(false)}
+      />
+    </>
   );
 };

--- a/screens/main/index.js
+++ b/screens/main/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { ActionCreators } from "redux-undo";
 
 import {
   addTask,
@@ -10,7 +11,7 @@ import {
 import Main from "./Main";
 
 export default () => {
-  const tasks = useSelector(state => state.tasks);
+  const tasks = useSelector(state => state.tasks.present);
 
   const dispatch = useDispatch();
 
@@ -26,6 +27,8 @@ export default () => {
   const handleMoveTask = ({ task, selectedDate, previousDate }) =>
     dispatch(moveTask({ task, selectedDate, previousDate }));
 
+  const undo = () => dispatch(ActionCreators.undo());
+
   return (
     <Main
       tasks={tasks}
@@ -33,6 +36,7 @@ export default () => {
       handleToggleCompleteTask={handleToggleCompleteTask}
       handleRemoveTask={handleRemoveTask}
       handleMoveTask={handleMoveTask}
+      undo={undo}
     />
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5279,6 +5279,11 @@ redux-thunk@^2.3.0:
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
   integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
 
+redux-undo@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/redux-undo/-/redux-undo-1.0.0.tgz#7688f0ae3874e0da35077de4fb1753c5d2e66a7a"
+  integrity sha512-WhCbkQyzY3KgqR+3wF1wR/O9WhvTsYGxKhwX5H1nWLA0q9AHrtHWgj4WQhTIJr5HzUR5uJyHm/Dnu5fiSvqL7w==
+
 redux@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.5.tgz#4db5de5816e17891de8a80c424232d06f051d93f"


### PR DESCRIPTION
This PR adds undo/redo logic and functionality into our state tree. It is configured such that it even works with `redux-persist` meaning that users can undo and redo events after they have closed the application. My idea for this was was to allow users to ultimately undo the deletion and updating of tasks (similar to the gmail app). The UI for this feature will come in a separate PR.

I prepared a demo below which shows cross session undo functionality but have removed the ugly blue button from this PR:
![undo-madness](https://user-images.githubusercontent.com/13072035/75166001-77c0ab80-56e0-11ea-8b7d-107f484a7430.gif)

The concept is actually extremely simple here and this feature was built using `redux-undo` https://github.com/omnidan/redux-undo and by following the explanation here: https://redux.js.org/recipes/implementing-undo-history/.


<img width="514" alt="Screen Shot 2020-02-24 at 8 29 47 AM" src="https://user-images.githubusercontent.com/13072035/75165928-5cee3700-56e0-11ea-9831-c9f9cc608fd3.png">

